### PR TITLE
Add image upload functionality for bulletins and news/events

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -9,11 +9,13 @@ from flask_login import (
     current_user,
 )
 from werkzeug.security import generate_password_hash, check_password_hash
+from werkzeug.utils import secure_filename
 from datetime import datetime
 import pytz
 from dateutil import parser
 from dotenv import load_dotenv
 from supabase import create_client, Client
+import time
 
 # Load environment variables from .env file
 load_dotenv()
@@ -39,6 +41,59 @@ login_manager.login_view = "admin_login"
 def get_manila_time():
     manila_tz = pytz.timezone("Asia/Manila")
     return datetime.now(manila_tz)
+
+# Helper function to upload image to Supabase Storage
+def upload_to_supabase_storage(file, bucket_name):
+    if not file or not file.filename:
+        app.logger.info("upload_to_supabase_storage: No file or filename provided.")
+        return None
+
+    try:
+        # Corrected f-string:
+        filename = f"{int(time.time())}_{secure_filename(file.filename)}"
+
+        app.logger.info(f"Attempting to upload {filename} to bucket {bucket_name}")
+
+        # Perform the upload
+        supabase.storage.from_(bucket_name).upload(
+            path=filename,
+            file=file.read(), # file.read() is important to get bytes
+            file_options={"content-type": file.content_type}
+        )
+
+        # If no exception was raised, the upload is successful.
+        # Get the public URL using the Supabase client's method.
+        public_url = supabase.storage.from_(bucket_name).get_public_url(filename)
+        app.logger.info(f"Successfully uploaded {filename} to {bucket_name}. Public URL: {public_url}")
+        return public_url
+
+    except Exception as e:
+        app.logger.error(f"Error uploading {file.filename if file else 'unknown file'} to {bucket_name}: {type(e).__name__} - {str(e)}")
+        return None
+
+# Helper function to delete image from Supabase Storage
+def delete_from_supabase_storage(image_url, bucket_name):
+    if not image_url:
+        return False
+    try:
+        # Extract filename from URL
+        filename = image_url.split(f"{bucket_name}/")[-1]
+        if not filename:
+            return False
+        response = supabase.storage.from_(bucket_name).remove([filename])
+        if response.status_code == 200 and response.json(): # Check if deletion was successful
+             # Check if the first item in the response list (if any) indicates success
+            if response.json()[0].get('message') == 'Successfully removed':
+                return True
+            else:
+                app.logger.error(f"Supabase delete error response: {response.json()}")
+                return False
+        else:
+            app.logger.error(f"Supabase delete error status {response.status_code}: {response.json()}")
+            return False
+    except Exception as e:
+        app.logger.error(f"Error deleting from Supabase: {e}")
+        return False
 
 class User(UserMixin):
     def __init__(self, id, username, password_hash, name, role):
@@ -74,7 +129,7 @@ def load_user(user_id):
 def index():
     bulletins_resp = (
         supabase.table("bulletin_posts")
-        .select("*")
+        .select("*, image_url")
         .eq("is_active", True)
         .order("date_posted", desc=True)
         .limit(8)
@@ -82,7 +137,7 @@ def index():
     )
     news_resp = (
         supabase.table("news_posts")
-        .select("*")
+        .select("*, image_url")
         .eq("is_active", True)
         .order("date_posted", desc=True)
         .limit(8)
@@ -159,7 +214,7 @@ def admin_dashboard():
 @app.route("/admin/bulletins")
 @login_required
 def admin_bulletins():
-    bulletins_resp = supabase.table("bulletin_posts").select("*").order("date_posted", desc=True).execute()
+    bulletins_resp = supabase.table("bulletin_posts").select("*, image_url").order("date_posted", desc=True).execute()
     bulletins = bulletins_resp.data or []
     return render_template("admin/bulletins/index.html", bulletins=bulletins)
 
@@ -171,6 +226,15 @@ def admin_create_bulletin():
         title = request.form.get("title")
         content = request.form.get("content")
         is_active = bool(request.form.get("is_active"))
+        image_file = request.files.get("image")
+        image_url = None
+
+        if image_file:
+            image_url = upload_to_supabase_storage(image_file, "bulletin-images")
+            if not image_url:
+                flash("Image upload failed. Please try again.", "danger")
+                return render_template("admin/bulletins/create.html")
+
 
         data = {
             "title": title,
@@ -178,6 +242,7 @@ def admin_create_bulletin():
             "is_active": is_active,
             "created_by": current_user.id,
             "date_posted": get_manila_time().isoformat(),
+            "image_url": image_url,
         }
 
         supabase.table("bulletin_posts").insert(data).execute()
@@ -191,7 +256,7 @@ def admin_create_bulletin():
 @app.route("/admin/bulletins/edit/<int:id>", methods=["GET", "POST"])
 @login_required
 def admin_edit_bulletin(id):
-    resp = supabase.table("bulletin_posts").select("*").eq("id", id).single().execute()
+    resp = supabase.table("bulletin_posts").select("*, image_url").eq("id", id).single().execute()
     bulletin = resp.data
 
     if not bulletin:
@@ -202,12 +267,29 @@ def admin_edit_bulletin(id):
         title = request.form.get("title")
         content = request.form.get("content")
         is_active = bool(request.form.get("is_active"))
+        image_file = request.files.get("image")
+        remove_image = request.form.get("remove_image") == "true"
+        old_image_url = bulletin.get("image_url")
 
         update_data = {
             "title": title,
             "content": content,
             "is_active": is_active,
         }
+
+        if remove_image:
+            if old_image_url:
+                delete_from_supabase_storage(old_image_url, "bulletin-images")
+            update_data["image_url"] = None
+        elif image_file:
+            if old_image_url:
+                delete_from_supabase_storage(old_image_url, "bulletin-images")
+            new_image_url = upload_to_supabase_storage(image_file, "bulletin-images")
+            if new_image_url:
+                update_data["image_url"] = new_image_url
+            else:
+                flash("Image upload failed. Please try again.", "danger")
+                return render_template("admin/bulletins/edit.html", bulletin=bulletin)
 
         supabase.table("bulletin_posts").update(update_data).eq("id", id).execute()
 
@@ -220,6 +302,13 @@ def admin_edit_bulletin(id):
 @app.route("/admin/bulletins/delete/<int:id>", methods=["POST"])
 @login_required
 def admin_delete_bulletin(id):
+    # Fetch the bulletin to get its image_url before deleting
+    resp = supabase.table("bulletin_posts").select("image_url").eq("id", id).single().execute()
+    bulletin_data = resp.data
+
+    if bulletin_data and bulletin_data.get("image_url"):
+        delete_from_supabase_storage(bulletin_data["image_url"], "bulletin-images")
+
     supabase.table("bulletin_posts").delete().eq("id", id).execute()
     flash("Bulletin deleted successfully!", "success")
     return redirect(url_for("admin_bulletins"))
@@ -230,7 +319,7 @@ def admin_delete_bulletin(id):
 @app.route("/admin/news")
 @login_required
 def admin_news():
-    news_resp = supabase.table("news_posts").select("*").order("date_posted", desc=True).execute()
+    news_resp = supabase.table("news_posts").select("*, image_url").order("date_posted", desc=True).execute()
     news_items = news_resp.data or []
     return render_template("admin/news/index.html", news_items=news_items)
 
@@ -242,6 +331,14 @@ def admin_create_news():
         title = request.form.get("title")
         content = request.form.get("content")
         is_active = bool(request.form.get("is_active"))
+        image_file = request.files.get("image")
+        image_url = None
+
+        if image_file:
+            image_url = upload_to_supabase_storage(image_file, "news-and-events-images")
+            if not image_url:
+                flash("Image upload failed. Please try again.", "danger")
+                return render_template("admin/news/create.html")
 
         data = {
             "title": title,
@@ -249,6 +346,7 @@ def admin_create_news():
             "is_active": is_active,
             "created_by": current_user.id,
             "date_posted": get_manila_time().isoformat(),
+            "image_url": image_url,
         }
 
         supabase.table("news_posts").insert(data).execute()
@@ -262,7 +360,7 @@ def admin_create_news():
 @app.route("/admin/news/edit/<int:id>", methods=["GET", "POST"])
 @login_required
 def admin_edit_news(id):
-    resp = supabase.table("news_posts").select("*").eq("id", id).single().execute()
+    resp = supabase.table("news_posts").select("*, image_url").eq("id", id).single().execute()
     news = resp.data
 
     if not news:
@@ -273,12 +371,29 @@ def admin_edit_news(id):
         title = request.form.get("title")
         content = request.form.get("content")
         is_active = bool(request.form.get("is_active"))
+        image_file = request.files.get("image")
+        remove_image = request.form.get("remove_image") == "true"
+        old_image_url = news.get("image_url")
 
         update_data = {
             "title": title,
             "content": content,
             "is_active": is_active,
         }
+
+        if remove_image:
+            if old_image_url:
+                delete_from_supabase_storage(old_image_url, "news-and-events-images")
+            update_data["image_url"] = None
+        elif image_file:
+            if old_image_url:
+                delete_from_supabase_storage(old_image_url, "news-and-events-images")
+            new_image_url = upload_to_supabase_storage(image_file, "news-and-events-images")
+            if new_image_url:
+                update_data["image_url"] = new_image_url
+            else:
+                flash("Image upload failed. Please try again.", "danger")
+                return render_template("admin/news/edit.html", news=news)
 
         supabase.table("news_posts").update(update_data).eq("id", id).execute()
 
@@ -291,6 +406,13 @@ def admin_edit_news(id):
 @app.route("/admin/news/delete/<int:id>", methods=["POST"])
 @login_required
 def admin_delete_news(id):
+    # Fetch the news item to get its image_url before deleting
+    resp = supabase.table("news_posts").select("image_url").eq("id", id).single().execute()
+    news_data = resp.data
+
+    if news_data and news_data.get("image_url"):
+        delete_from_supabase_storage(news_data["image_url"], "news-and-events-images")
+
     supabase.table("news_posts").delete().eq("id", id).execute()
     flash("News item deleted successfully!", "success")
     return redirect(url_for("admin_news"))

--- a/api/templates/admin/bulletins/create.html
+++ b/api/templates/admin/bulletins/create.html
@@ -10,7 +10,7 @@
   </div>
   <div class="card">
     <div class="card-body">
-      <form action="{{ url_for('admin_create_bulletin') }}" method="POST">
+      <form action="{{ url_for('admin_create_bulletin') }}" method="POST" enctype="multipart/form-data">
         <div class="mb-3">
           <label for="title" class="form-label">Title</label>
           <input type="text" class="form-control" id="title" name="title" required>
@@ -19,7 +19,16 @@
       <label for="content" class="form-label">Content</label>
       <textarea class="form-control" id="content" name="content" rows="6" required></textarea>
     </div>
-    
+    <div class="mb-3">
+      <label for="image" class="form-label">Image (Optional)</label>
+      <input
+        type="file"
+        class="form-control"
+        id="image"
+        name="image"
+        accept="image/jpeg,image/jpg,image/png"
+      />
+    </div>
     <div class="mb-3 form-check">
       <input type="checkbox" class="form-check-input" id="is_active" name="is_active" checked>
       <label class="form-check-label" for="is_active">Active</label>

--- a/api/templates/admin/bulletins/edit.html
+++ b/api/templates/admin/bulletins/edit.html
@@ -10,7 +10,7 @@
   </div>
   <div class="card">
     <div class="card-body">
-      <form action="{{ url_for('admin_edit_bulletin', id=bulletin.id) }}" method="POST">
+      <form action="{{ url_for('admin_edit_bulletin', id=bulletin.id) }}" method="POST" enctype="multipart/form-data">
         <div class="mb-3">
           <label for="title" class="form-label">Title</label>
           <input type="text" class="form-control" id="title" name="title" value="{{ bulletin.title }}" required>
@@ -19,7 +19,26 @@
       <label for="content" class="form-label">Content</label>
       <textarea class="form-control" id="content" name="content" rows="6" required>{{ bulletin.content }}</textarea>
     </div>
-    
+    {% if bulletin.image_url %}
+    <div class="mb-3">
+      <label class="form-label">Current Image:</label><br>
+      <img src="{{ bulletin.image_url }}" alt="Current Bulletin Image" style="max-width: 200px; max-height: 200px; margin-bottom: 10px;">
+      <div class="form-check">
+        <input type="checkbox" class="form-check-input" id="remove_image" name="remove_image" value="true">
+        <label class="form-check-label" for="remove_image">Remove current image</label>
+      </div>
+    </div>
+    {% endif %}
+    <div class="mb-3">
+      <label for="image" class="form-label">Upload New Image (Optional):</label>
+      <input
+        type="file"
+        name="image"
+        id="image"
+        class="form-control"
+        accept="image/jpeg,image/jpg,image/png"
+      />
+    </div>
     <div class="mb-3 form-check">
       <input type="checkbox" class="form-check-input" id="is_active" name="is_active" {% if bulletin.is_active %}checked{% endif %}>
       <label class="form-check-label" for="is_active">Active</label>

--- a/api/templates/admin/bulletins/index.html
+++ b/api/templates/admin/bulletins/index.html
@@ -15,18 +15,26 @@
           <thead>
             <tr>
               <th>Title</th>
+              <th>Image</th>
               <th>Date Posted</th>
               <th>Status</th>
               <th>Actions</th>
             </tr>
           </thead>
           <tbody>
-            {% for bulletin in bulletins %}
+            {% for bulletin in bulletins %}  {# Assuming 'bulletins' is the context variable passed from the route #}
             <tr>
               <td>{{ bulletin.title }}</td>
+              <td>
+                {% if bulletin.image_url %}
+                  <img src="{{ bulletin.image_url }}" alt="Bulletin Image" style="width: 100px; height: auto;">
+                {% else %}
+                  No Image
+                {% endif %}
+              </td>
               <td><small><i class="far fa-calendar-alt"></i>
-       {{ bulletin.date_posted | datetimeformat }}</small>
-</td>
+                {{ bulletin.date_posted | datetimeformat }}</small>
+              </td>
               <td>
                 {% if bulletin.is_active %}
                 <span class="badge bg-success">Active</span>
@@ -41,23 +49,23 @@
                 <button type="button" class="btn btn-sm btn-danger" data-bs-toggle="modal" data-bs-target="#deleteModal{{ bulletin.id }}">
                   <i class="fas fa-trash"></i>
                 </button>
-            <!-- Delete Modal -->
-            <div class="modal fade" id="deleteModal{{ bulletin.id }}" tabindex="-1" aria-hidden="true">
-              <div class="modal-dialog">
-                <div class="modal-content">
-                  <div class="modal-header">
-                    <h5 class="modal-title">Confirm Delete</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                  </div>
-                  <div class="modal-body">
-                    Are you sure you want to delete the bulletin: <strong>{{ bulletin.title }}</strong>?
-                  </div>
-                  <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                    <form action="{{ url_for('admin_delete_bulletin', id=bulletin.id) }}" method="POST" class="d-inline">
-                      <button type="submit" class="btn btn-danger">Delete</button>
-                    </form>
-                  </div>
+                <!-- Delete Modal -->
+                <div class="modal fade" id="deleteModal{{ bulletin.id }}" tabindex="-1" aria-hidden="true">
+                  <div class="modal-dialog">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h5 class="modal-title">Confirm Delete</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                      </div>
+                      <div class="modal-body">
+                        Are you sure you want to delete the bulletin item: <strong>{{ bulletin.title }}</strong>?
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <form action="{{ url_for('admin_delete_bulletin', id=bulletin.id) }}" method="POST" class="d-inline">
+                          <button type="submit" class="btn btn-danger">Delete</button>
+                        </form>
+                      </div>
                 </div>
               </div>
             </div>
@@ -65,7 +73,7 @@
         </tr>
         {% else %}
         <tr>
-          <td colspan="4" class="text-center">No bulletins found</td>
+          <td colspan="5" class="text-center">No bulletin items found</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/api/templates/admin/news/index.html
+++ b/api/templates/admin/news/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/layout.html" %}
-{% block title %}Bulletin Board - E-Looc Admin{% endblock %}
+{% block title %}News & Events - E-Looc Admin{% endblock %}
 {% block content %}
 <div class="container-fluid">
   <div class="d-flex justify-content-between align-items-center mb-4">
@@ -15,6 +15,7 @@
           <thead>
             <tr>
               <th>Title</th>
+              <th>Image</th>
               <th>Date Posted</th>
               <th>Status</th>
               <th>Actions</th>
@@ -24,6 +25,13 @@
             {% for news_item in news_items %}
             <tr>
               <td>{{ news_item.title }}</td>
+              <td>
+                {% if news_item.image_url %}
+                  <img src="{{ news_item.image_url }}" alt="News Image" style="width: 100px; height: auto;">
+                {% else %}
+                  No Image
+                {% endif %}
+              </td>
               <td><small><i class="far fa-calendar-alt"></i>
        {{ news_item.date_posted | datetimeformat }}</small>
 </td>
@@ -65,7 +73,7 @@
         </tr>
         {% else %}
         <tr>
-          <td colspan="4" class="text-center">No news items found</td>
+          <td colspan="5" class="text-center">No news items found</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/api/templates/home.html
+++ b/api/templates/home.html
@@ -191,6 +191,9 @@
     <div class="bulletin-cards" id="bulletin-cards">
         {% for bulletin in bulletins %}
         <div class="card">
+            {% if bulletin.image_url %}
+                <img src="{{ bulletin.image_url }}" alt="{{ bulletin.title }} Image" style="width:100%; max-height:300px; object-fit: cover; margin-bottom: 10px;">
+            {% endif %}
             <h3>{{ bulletin.title }}</h3>
             <small><i class="far fa-calendar-alt"></i> {{ bulletin.date_posted | datetimeformat  }}
 </small>
@@ -205,6 +208,9 @@
     <div class="bulletin-cards">
         {% for news_item in news %}
         <div class="card">
+            {% if news_item.image_url %}
+                <img src="{{ news_item.image_url }}" alt="{{ news_item.title }} Image" style="width:100%; max-height:300px; object-fit: cover; margin-bottom: 10px;">
+            {% endif %}
             <h3>{{ news_item.title }}</h3>
             <small><i class="far fa-calendar-alt"></i> {{ news_item.date_posted | datetimeformat }}
 </small>


### PR DESCRIPTION
This commit implements the ability to upload a single image (JPEG, PNG) per bulletin post or news/events post via the admin interface.

Key changes include:
- Updated 'bulletin_posts' and 'news_posts' Supabase tables to include an 'image_url' field (manual migration).
- Created Supabase Storage buckets 'bulletin-images' and 'news-and-events-images' (manual setup).
- Modified 'api/main.py':
    - Added helper functions to upload images to and delete images from Supabase Storage.
    - Updated CRUD functions for bulletins and news to handle image processing:
        - Create: Upload image and store URL.
        - Edit: Allow changing or removing an image (deletes old image from storage if replaced/removed). - Delete: Remove associated image from storage.
    - Ensured 'image_url' is fetched with post data.
- Updated Admin HTML Templates:
    - 'create.html' and 'edit.html' for bulletins and news: - Added file input fields. - Set form enctype to 'multipart/form-data'. - Edit forms display current image and allow removal.
    - 'index.html' for bulletins and news:
        - Display image thumbnails in the posts list.
- Updated 'home.html' to display uploaded images for bulletin and news posts.